### PR TITLE
Fix twitter card image URL generation

### DIFF
--- a/themes/SuperNormal/layouts/partials/twittercard.html
+++ b/themes/SuperNormal/layouts/partials/twittercard.html
@@ -1,6 +1,16 @@
 
 <meta name="twitter:card" content="summary_large_image"/>
-<meta name="twitter:image" content="{{ .Permalink }}images/featured.jpg"/>
+{{- $image := "" -}}
+{{- with .Params.images -}}
+  {{- $image = index . 0 -}}
+{{- else if .Params.featured_image -}}
+  {{- $image = .Params.featured_image -}}
+{{- else if .Site.Params.images -}}
+  {{- $image = index .Site.Params.images 0 -}}
+{{- end -}}
+{{- with $image }}
+<meta name="twitter:image" content="{{ . | absURL }}"/>
+{{- end }}
 
 <meta name="twitter:title" content="{{ .Title }}"/>
 <meta name="twitter:description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end -}}"/>


### PR DESCRIPTION
## Summary
- update the twitter card partial to pick the correct image instead of appending to the permalink
- fall back to page- and site-level image configuration and generate an absolute URL for social sharing

## Testing
- not run (Hugo CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ed0980f04083338d2274a10f1df8bc